### PR TITLE
Fix new 1.15 update "|dam" focus tree parse issue

### DIFF
--- a/src/hoiformat/hoiparser.ts
+++ b/src/hoiformat/hoiparser.ts
@@ -106,7 +106,7 @@ function tokenizer<T extends string>(input: string, tokenRegexStrings: Record<T,
 type HOITokenType = 'comment' | 'symbol' | 'operator' | 'string' | 'number' | 'unitnumber' | 'eof';
 const tokenRegexStrings: Record<HOITokenType, [string, number]> = {
     comment: ['#.*(?:[\\r\\n]|$)', 0],
-    symbol: ['(?:\\d+\\.)?[a-zA-Z_@\\[\\]][\\w:\\._@\\[\\]\\-\\?\\^\\/\\u00A0-\\u024F]*', 40],
+    symbol: ['(?:\\d+\\.)?[a-zA-Z_@\\[\\]][\\w:\\._@\\[\\]\\-\\?\\^\\/\\u00A0-\\u024F|]*', 40],
     operator: ['[={}<>;,]|>=|<=|!=', 10],
     string: ['"(?:\\\\"|\\\\\\\\|[^"])*"', 10],
     number: ['-?\\d*\\.\\d+|-?\\d+|0x\\d+', 50],


### PR DESCRIPTION
Fix 1.15 "|dam" parse issue.

Captured parse result in JSON below:

```
{
  name: "custom_effect_tooltip",
  nameToken: {
    value: "custom_effect_tooltip",
    start: 27775,
    end: 27796,
    type: "symbol",
  },
  operator: "=",
  operatorToken: {
    value: "=",
    start: 27797,
    end: 27798,
    type: "operator",
  },
  value: [
    {
      name: "localization_key",
      nameToken: {
        value: "localization_key",
        start: 27806,
        end: 27822,
        type: "symbol",
      },
      operator: "=",
      operatorToken: {
        value: "=",
        start: 27823,
        end: 27824,
        type: "operator",
      },
      value: {
        name: "building_state_modifier|dam",
      },
      valueStartToken: {
        value: "building_state_modifier|dam",
        start: 27825,
        end: 27852,
        type: "symbol",
      },
      valueEndToken: {
        value: "building_state_modifier|dam",
        start: 27825,
        end: 27852,
        type: "symbol",
      },
      valueAttachment: null,
      valueAttachmentToken: null,
    },
    {
      name: "INDENT",
      nameToken: {
        value: "INDENT",
        start: 27858,
        end: 27864,
        type: "symbol",
      },
      operator: "=",
      operatorToken: {
        value: "=",
        start: 27865,
        end: 27866,
        type: "operator",
      },
      value: "    ",
      valueStartToken: {
        value: "\"    \"",
        start: 27867,
        end: 27873,
        type: "string",
      },
      valueEndToken: {
        value: "\"    \"",
        start: 27867,
        end: 27873,
        type: "string",
      },
      valueAttachment: null,
      valueAttachmentToken: null,
    },
  ],
  valueStartToken: {
    value: "{",
    start: 27799,
    end: 27800,
    type: "operator",
  },
  valueEndToken: {
    value: "}",
    start: 27878,
    end: 27879,
    type: "operator",
  },
  valueAttachment: null,
  valueAttachmentToken: null,
}
```