### PR TITLE
Fix focus preview custom icons and overlays

### DIFF
--- a/src/previewdef/focustree/contentbuilder.ts
+++ b/src/previewdef/focustree/contentbuilder.ts
@@ -210,6 +210,18 @@ async function renderFocus(focus: Focus, styleTable: StyleTable, gfxFiles: strin
     
     styleTable.style('focus-icon-' + normalizeForStyle('-empty'), () => 'background: grey;');
 
+    if (focus.overlay) {
+        const overlaySprite = await getSpriteByGfxName(focus.overlay, gfxFiles);
+        if (overlaySprite !== undefined) {
+            styleTable.style('focus-overlay-' + normalizeForStyle(focus.overlay), () =>
+                `background-image: url(${overlaySprite.image.uri});
+                background-size: ${overlaySprite.image.width}px;
+                background-position: center;
+                background-repeat: no-repeat;`
+            );
+        }
+    }
+
     let textContent = focus.id;
     if (localisationIndex){
         let localizedText = await getLocalisedTextQuick(focus.id);
@@ -233,6 +245,7 @@ async function renderFocus(focus: Focus, styleTable: StyleTable, gfxFiles: strin
             background-position-x: center;
             background-position-y: calc(50% - 18px);
             background-repeat: no-repeat;
+            position: relative;
             width: 100%;
             height: 100%;
             text-align: center;
@@ -243,15 +256,29 @@ async function renderFocus(focus: Focus, styleTable: StyleTable, gfxFiles: strin
     end="${focus.token?.end}"
     ${file === focus.file ? '' : `file="${focus.file}"`}
     title="${focus.id}\n({{position}})">
-        <div class="focus-checkbox ${styleTable.style('focus-checkbox', () => `position: absolute; top: 1px;`)}">
+        <div class="focus-checkbox ${styleTable.style('focus-checkbox', () => `position: absolute; top: 1px; z-index: 1;`)}">
             <input id="checkbox-${normalizeForStyle(focus.id)}" type="checkbox"/>
         </div>
+        ${focus.overlay ? `<div class="
+            ${styleTable.style('focus-overlay-common', () => `
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 100%;
+                height: 100%;
+                pointer-events: none;
+                z-index: 0;
+            `)}
+            ${styleTable.name('focus-overlay-' + normalizeForStyle(focus.overlay))}
+        "></div>` : ''}
         <span
         class="${styleTable.style('focus-span', () => `
             margin: 10px -400px;
             margin-top: 85px;
             text-align: center;
             display: inline-block;
+            position: relative;
+            z-index: 1;
         `)}">
         ${textContent}
         </span>

--- a/src/previewdef/focustree/loader.ts
+++ b/src/previewdef/focustree/loader.ts
@@ -6,6 +6,7 @@ import { uniq, flatten, chain } from "lodash";
 import { getGfxContainerFiles } from "../../util/gfxindex";
 import { sharedFocusIndex } from "../../util/featureflags";
 import { findFileByFocusKey } from "../../util/sharedFocusIndex";
+import { listFilesFromModOrHOI4 } from "../../util/fileloader";
 
 export interface FocusTreeLoaderResult {
     focusTrees: FocusTree[];
@@ -50,10 +51,19 @@ export class FocusTreeLoader extends ContentLoader<FocusTreeLoaderResult> {
 
         const focusTrees = getFocusTreeWithFocusFile(file, sharedFocusTrees, this.file, constants);
 
+        const focusGfxNames = chain(focusTrees)
+            .flatMap(ft => Object.values(ft.focuses))
+            .flatMap(f => [...f.icon.map(i => i.icon), f.overlay])
+            .value();
+        const workspaceGfxFiles = (await listFilesFromModOrHOI4('interface', { hoi4: false, recursively: true }))
+            .filter(f => f.toLocaleLowerCase().endsWith('.gfx'))
+            .map(f => 'interface/' + f);
+
         const gfxDependencies = [
             ...dependencies.filter(d => d.type === 'gfx').map(d => d.path),
             ...flatten(focusTreeDepFiles.map(f => f.result.gfxFiles)),
-            ...await getGfxContainerFiles(chain(focusTrees).flatMap(ft => Object.values(ft.focuses)).flatMap(f => f.icon).map(i => i.icon).value()),
+            ...workspaceGfxFiles,
+            ...await getGfxContainerFiles(focusGfxNames),
         ];
 
         return {

--- a/src/previewdef/focustree/schema.ts
+++ b/src/previewdef/focustree/schema.ts
@@ -39,6 +39,7 @@ export interface Focus {
     token: Token | undefined;
     file: string;
     text?: string;
+    overlay?: string;
 }
 
 export interface FocusWarning extends Warning<string> {
@@ -71,6 +72,7 @@ interface FocusDef {
     offset: OffsetDef[];
     _token: Token;
     text?: string;
+    overlay?: string;
 }
 
 interface FocusIconDef {
@@ -142,6 +144,7 @@ const focusSchema: SchemaDef<FocusDef> = {
         _type: 'array',
     },
     text: "string",
+    overlay: "string",
 };
 
 const focusTreeSchema: SchemaDef<FocusTreeDef> = {
@@ -332,6 +335,7 @@ function getFocus(hoiFocus: HOIPartial<FocusDef>, conditionExprs: ConditionItem[
     }));
 
     const text = hoiFocus.text;
+    const overlay = hoiFocus.overlay;
 
     return {
         id,
@@ -348,6 +352,7 @@ function getFocus(hoiFocus: HOIPartial<FocusDef>, conditionExprs: ConditionItem[
         token: hoiFocus._token,
         file: filePath,
         text,
+        overlay,
     };
 }
 


### PR DESCRIPTION
This patch improves national focus preview icon loading for mods.

Changes:
- Parse and render the `overlay` field on focuses.
- Include overlay sprite names in focus tree GFX dependency lookup.
- Include workspace `interface/*.gfx` files in focus tree preview dependencies, so mod-defined focus icons can be resolved even when the optional GFX index feature is not enabled.

This keeps the existing base-game/DLC loading behavior intact and only expands focus preview dependencies needed by the current workspace.