### PR TITLE
focustree search filters

### DIFF
--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -23,6 +23,7 @@ const internalTable = /* SOT Do not remove this comment */{
     "focustree.focustree": "Focus tree: ",
     "focustree.nofocustree": "No focus tree.",
     "focustree.search": "Search: ",
+    "focustree.searchfilters": "Focus filters",
     "focustree.sharedfocuses": "<Shared focuses>",
     "focustree.warnings": "Toggle warnings",
     "focustree.warnings.focusidconflict": "There're more than one focuses with ID {0} in file: {1}.",

--- a/i18n/ko.ts
+++ b/i18n/ko.ts
@@ -23,6 +23,7 @@ const table: Partial<typeof __table> = {
     "focustree.focustree": "중점 계통도: ",
     "focustree.nofocustree": "중점 계통도 없음.",
     "focustree.search": "검색: ",
+    "focustree.searchfilters": "국가중점 분류",
     "focustree.sharedfocuses": "<공유 중점>",
     "focustree.warnings": "경고 활성/비활성",
     "focustree.warnings.focusidconflict": "중점 ID {0} 가 {1} 파일 내에 2개 이상 존재합니다.",

--- a/i18n/ru.ts
+++ b/i18n/ru.ts
@@ -23,6 +23,7 @@ const table: Partial<typeof __table> = {
     "focustree.focustree": "Ветка фокусов: ",
     "focustree.nofocustree": "Нет ветки фокусов.",
     "focustree.search": "Поиск: ",
+    "focustree.searchfilters": "Категории фокусов",
     "focustree.sharedfocuses": "<Общие фокусы>",
     "focustree.warnings": "Включить предупреждения",
     "focustree.warnings.focusidconflict": "Здесь более одного фокуса с ID {0} в файле: {1}.",

--- a/i18n/template.ts
+++ b/i18n/template.ts
@@ -23,6 +23,7 @@ const table: Partial<typeof __table> = {
     "focustree.focustree": "Focus tree: ",
     "focustree.nofocustree": "No focus tree.",
     "focustree.search": "Search: ",
+    "focustree.searchfilters": "Focus filters",
     "focustree.sharedfocuses": "<Shared focuses>",
     "focustree.warnings": "Toggle warnings",
     "focustree.warnings.focusidconflict": "There're more than one focuses with ID {0} in file: {1}.",

--- a/i18n/zh-cn.ts
+++ b/i18n/zh-cn.ts
@@ -23,6 +23,7 @@ const table: Partial<typeof __table> = {
     "focustree.focustree": "国策树：",
     "focustree.nofocustree": "没有国策树。",
     "focustree.search": "搜索：",
+    "focustree.searchfilters": "国策分类",
     "focustree.sharedfocuses": "<共享国策>",
     "focustree.warnings": "开启/收起警告列表",
     "focustree.warnings.focusidconflict": "在这个文件中有多个国策的id字段为{0}：{1}。",

--- a/src/previewdef/focustree/contentbuilder.ts
+++ b/src/previewdef/focustree/contentbuilder.ts
@@ -102,6 +102,8 @@ async function renderFocusTrees(focusTrees: FocusTree[], styleTable: StyleTable,
             pointer-events: none;
         `)}">Continuous focuses</div>`;
 
+    const focusFilterControls = await renderFocusFilterControls(focusTrees, styleTable, gfxFiles);
+
     return (
         `<div id="dragger" additionalDraggerHostId="focustreecontent" class="${styleTable.oneTimeStyle('dragger', () => `
             width: 100vw;
@@ -114,9 +116,77 @@ async function renderFocusTrees(focusTrees: FocusTree[], styleTable: StyleTable,
             <div id="focustreeplaceholder"></div>
             ${continuousFocusContent}
         </div>` +
+        focusFilterControls +
         renderWarningContainer(styleTable) +
         renderToolBar(focusTrees, styleTable)
     );
+}
+
+async function renderFocusFilterControls(focusTrees: FocusTree[], styleTable: StyleTable, gfxFiles: string[]): Promise<string> {
+    const filters = new Set<string>();
+    focusTrees.forEach(focusTree => {
+        for (const focus of Object.values(focusTree.focuses)) {
+            for (const filter of focus.searchFilters) {
+                filters.add(filter);
+            }
+        }
+    });
+
+    if (filters.size === 0) {
+        return '';
+    }
+
+    const buttonClass = styleTable.style('focus-filter-button', () => `
+        width: 34px;
+        height: 34px;
+        padding: 2px;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        font-size: 9px;
+        overflow: hidden;
+    `);
+    styleTable.style('focus-filter-button', () => `
+        box-shadow: 0 0 0 2px var(--vscode-focusBorder);
+    `, '[aria-pressed="true"]');
+    const buttons = await Promise.all(Array.from(filters).map(async filter => {
+        const text = getFocusFilterText(filter);
+        const sprite = await getSpriteByGfxName(`GFX_${filter}`, gfxFiles);
+        const iconClass = sprite ? styleTable.style('focus-filter-' + normalizeForStyle(filter), () => `
+            background-image: url(${sprite.image.uri});
+        `) : '';
+        return `<button type="button"
+            class="focus-filter ${buttonClass} ${iconClass}"
+            data-focus-filter="${htmlEscape(filter)}"
+            aria-pressed="false"
+            title="${htmlEscape(text)}">${sprite ? '' : htmlEscape(text.substring(0, 3).toLocaleUpperCase())}</button>`;
+    }));
+
+    return `<div id="focus-filter-container"
+        aria-label="${localize('focustree.searchfilters', 'Focus filters')}"
+        class="${styleTable.style('focus-filter-container', () => `
+            position: fixed;
+            left: 10px;
+            bottom: 10px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            max-width: calc(100vw - 20px);
+            padding: 4px;
+            background: rgba(32, 32, 32, 0.75);
+            z-index: 1;
+        `)}">${buttons.join('')}</div>`;
+}
+
+function getFocusFilterText(filter: string): string {
+    const localisedText = localisationIndex.getLocalisedText(filter);
+    if (localisedText && localisedText !== filter) {
+        return localisedText;
+    }
+
+    return filter.replace(/^FOCUS_FILTER_/, '').split('_')
+        .map(word => word.length > 0 ? word[0].toLocaleUpperCase() + word.substring(1).toLocaleLowerCase() : word)
+        .join(' ');
 }
 
 function renderWarningContainer(styleTable: StyleTable) {

--- a/src/previewdef/focustree/contentbuilder.ts
+++ b/src/previewdef/focustree/contentbuilder.ts
@@ -174,7 +174,6 @@ async function renderFocusFilterControls(focusTrees: FocusTree[], styleTable: St
             max-width: calc(100vw - 20px);
             padding: 4px;
             background: rgba(32, 32, 32, 0.75);
-            z-index: 1;
         `)}">${buttons.join('')}</div>`;
 }
 

--- a/src/previewdef/focustree/loader.ts
+++ b/src/previewdef/focustree/loader.ts
@@ -49,7 +49,7 @@ export class FocusTreeLoader extends ContentLoader<FocusTreeLoaderResult> {
 
         const focusGfxNames = chain(focusTrees)
             .flatMap(ft => Object.values(ft.focuses))
-            .flatMap(f => [...f.icon.map(i => i.icon), f.overlay])
+            .flatMap(f => [...f.icon.map(i => i.icon), f.overlay, ...f.searchFilters.map(filter => `GFX_${filter}`)])
             .value();
 
         const gfxDependencies = [

--- a/src/previewdef/focustree/schema.ts
+++ b/src/previewdef/focustree/schema.ts
@@ -1,5 +1,5 @@
 import { Node, Token } from '../../hoiformat/hoiparser';
-import { convertNodeToJson, CustomMap, HOIPartial, Position, positionSchema, Raw, SchemaDef } from '../../hoiformat/schema';
+import { convertNodeToJson, CustomMap, Enum, HOIPartial, Position, positionSchema, Raw, SchemaDef } from '../../hoiformat/schema';
 import { normalizeNumberLike } from '../../util/hoi4gui/common';
 import { chain, flatten } from 'lodash';
 import { ConditionComplexExpr, ConditionItem, extractConditionalExprs, extractConditionValue, extractConditionValues } from '../../hoiformat/condition';
@@ -31,6 +31,7 @@ export interface Focus {
     icon: FocusIconWithCondition[];
     prerequisite: string[][];
     exclusive: string[];
+    searchFilters: string[];
     hasAllowBranch: boolean;
     inAllowBranch: string[];
     allowBranch: ConditionComplexExpr | undefined;
@@ -80,6 +81,7 @@ interface FocusDef {
     y: Raw;
     prerequisite: FocusOrORList[];
     mutually_exclusive: FocusOrORList[];
+    search_filters: Enum;
     relative_position_id: string;
     allow_branch: Raw[]; /* FIXME not symbol node */
     offset: OffsetDef[];
@@ -140,6 +142,7 @@ const focusSchema: SchemaDef<FocusDef> = {
         _innerType: focusOrORListSchema,
         _type: 'array',
     },
+    search_filters: 'enum',
     relative_position_id: 'string',
     allow_branch: {
         _innerType: 'raw',
@@ -358,6 +361,7 @@ function getFocus(hoiFocus: HOIPartial<FocusDef>, conditionExprs: ConditionItem[
         relativePositionId,
         prerequisite,
         exclusive,
+        searchFilters: hoiFocus.search_filters._values,
         hasAllowBranch,
         inAllowBranch: hasAllowBranch ? [id] : [],
         allowBranch: allowBranchCondition,

--- a/test/suite/focustree/schema.test.ts
+++ b/test/suite/focustree/schema.test.ts
@@ -1,10 +1,10 @@
 import * as assert from 'assert';
 import { parseHoi4File } from '../../../src/hoiformat/hoiparser';
-import { getFocusTree } from '../../../src/previewdef/focustree/schema';
+import { convertFocusFileNodeToJson } from '../../../src/previewdef/focustree/schema';
 
 suite('focus search filters', () => {
-    test('keeps search filters on regular, shared, and joint focuses', () => {
-        const focusTrees = getFocusTree(parseHoi4File(`
+    test('parses search filters on regular, shared, and joint focuses', () => {
+        const focusFile = convertFocusFileNodeToJson(parseHoi4File(`
             focus_tree = {
                 id = test_tree
                 focus = {
@@ -20,12 +20,11 @@ suite('focus search filters', () => {
                 id = TEST_JOINT_FOCUS
                 search_filters = { FOCUS_FILTER_INDUSTRY }
             }
-        `), [], 'test.txt');
+        `), {});
 
-        assert.deepStrictEqual(focusTrees.find(tree => tree.id === 'test_tree')?.focuses.TEST_FOCUS.searchFilters,
+        assert.deepStrictEqual(focusFile.focus_tree[0].focus[0].search_filters._values,
             ['FOCUS_FILTER_POLITICAL', 'FOCUS_FILTER_INNER_CIRCLE']);
-        const sharedFocuses = focusTrees.find(tree => tree.isSharedFocues)?.focuses;
-        assert.deepStrictEqual(sharedFocuses?.TEST_SHARED_FOCUS.searchFilters, ['FOCUS_FILTER_RESEARCH']);
-        assert.deepStrictEqual(sharedFocuses?.TEST_JOINT_FOCUS.searchFilters, ['FOCUS_FILTER_INDUSTRY']);
+        assert.deepStrictEqual(focusFile.shared_focus[0].search_filters._values, ['FOCUS_FILTER_RESEARCH']);
+        assert.deepStrictEqual(focusFile.joint_focus[0].search_filters._values, ['FOCUS_FILTER_INDUSTRY']);
     });
 });

--- a/test/suite/focustree/schema.test.ts
+++ b/test/suite/focustree/schema.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+import { parseHoi4File } from '../../../src/hoiformat/hoiparser';
+import { getFocusTree } from '../../../src/previewdef/focustree/schema';
+
+suite('focus search filters', () => {
+    test('keeps search filters on regular, shared, and joint focuses', () => {
+        const focusTrees = getFocusTree(parseHoi4File(`
+            focus_tree = {
+                id = test_tree
+                focus = {
+                    id = TEST_FOCUS
+                    search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INNER_CIRCLE }
+                }
+            }
+            shared_focus = {
+                id = TEST_SHARED_FOCUS
+                search_filters = { FOCUS_FILTER_RESEARCH }
+            }
+            joint_focus = {
+                id = TEST_JOINT_FOCUS
+                search_filters = { FOCUS_FILTER_INDUSTRY }
+            }
+        `), [], 'test.txt');
+
+        assert.deepStrictEqual(focusTrees.find(tree => tree.id === 'test_tree')?.focuses.TEST_FOCUS.searchFilters,
+            ['FOCUS_FILTER_POLITICAL', 'FOCUS_FILTER_INNER_CIRCLE']);
+        const sharedFocuses = focusTrees.find(tree => tree.isSharedFocues)?.focuses;
+        assert.deepStrictEqual(sharedFocuses?.TEST_SHARED_FOCUS.searchFilters, ['FOCUS_FILTER_RESEARCH']);
+        assert.deepStrictEqual(sharedFocuses?.TEST_JOINT_FOCUS.searchFilters, ['FOCUS_FILTER_INDUSTRY']);
+    });
+});

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -3,6 +3,8 @@ import * as Mocha from 'mocha';
 import * as glob from 'glob';
 
 export function run(): Promise<void> {
+    Object.assign(globalThis, { IS_WEB_EXT: false });
+
     // Create the mocha test
     const mocha = new Mocha({
         ui: 'tdd',

--- a/webviewsrc/focustree.ts
+++ b/webviewsrc/focustree.ts
@@ -33,13 +33,13 @@ let currentSearchContent = '';
 let selectedSearchFilter: string | undefined = getState().selectedSearchFilter;
 
 function search(searchContent: string, navigate: boolean = true) {
-    currentSearchContent = searchContent.toLocaleLowerCase();
+    currentSearchContent = searchContent.toLowerCase();
     const focuses = document.getElementsByClassName('focus');
     const searchedFocus: HTMLDivElement[] = [];
     let navigated = false;
     for (let i = 0; i < focuses.length; i++) {
         const focus = focuses[i] as HTMLDivElement;
-        if (currentSearchContent && focus.id.toLocaleLowerCase().replace(/^focus_/, '').includes(currentSearchContent)) {
+        if (currentSearchContent && focus.id.toLowerCase().replace(/^focus_/, '').includes(currentSearchContent)) {
             if (navigate && !navigated) {
                 focus.scrollIntoView({ block: 'center', inline: 'center' });
                 navigated = true;
@@ -57,7 +57,7 @@ function refreshFocusHighlights(): void {
     const focusTree = focusTrees[selectedFocusTreeIndex];
     for (const focusElement of Array.from(document.querySelectorAll<HTMLDivElement>('.focus'))) {
         const focusId = focusElement.id.replace(/^focus_/, '');
-        const matchesSearch = !!currentSearchContent && focusId.toLocaleLowerCase().includes(currentSearchContent);
+        const matchesSearch = !!currentSearchContent && focusId.toLowerCase().includes(currentSearchContent);
         const matchesFilter = selectedSearchFilter !== undefined &&
             focusTree.focuses[focusId]?.searchFilters.includes(selectedSearchFilter);
         focusElement.style.outline = matchesSearch ? '1px solid #E33' : matchesFilter ? '2px solid #FC3' : '';

--- a/webviewsrc/focustree.ts
+++ b/webviewsrc/focustree.ts
@@ -29,27 +29,41 @@ function showBranch(visibility: boolean, optionClass: string) {
     }
 };
 
+let currentSearchContent = '';
+let selectedSearchFilters: string[] = getState().selectedSearchFilters ?? [];
+
 function search(searchContent: string, navigate: boolean = true) {
+    currentSearchContent = searchContent.toLocaleLowerCase();
     const focuses = document.getElementsByClassName('focus');
     const searchedFocus: HTMLDivElement[] = [];
     let navigated = false;
     for (let i = 0; i < focuses.length; i++) {
         const focus = focuses[i] as HTMLDivElement;
-        if (searchContent && focus.id.toLowerCase().replace(/^focus_/, '').includes(searchContent)) {
-            focus.style.outline = '1px solid #E33';
-            focus.style.background = 'rgba(255, 0, 0, 0.5)';
+        if (currentSearchContent && focus.id.toLocaleLowerCase().replace(/^focus_/, '').includes(currentSearchContent)) {
             if (navigate && !navigated) {
                 focus.scrollIntoView({ block: 'center', inline: 'center' });
                 navigated = true;
             }
             searchedFocus.push(focus);
-        } else {
-            focus.style.outlineWidth = '0';
-            focus.style.background = 'transparent';
         }
     }
 
+    refreshFocusHighlights();
+
     return searchedFocus;
+}
+
+function refreshFocusHighlights(): void {
+    const focusTree = focusTrees[selectedFocusTreeIndex];
+    for (const focusElement of Array.from(document.querySelectorAll<HTMLDivElement>('.focus'))) {
+        const focusId = focusElement.id.replace(/^focus_/, '');
+        const matchesSearch = !!currentSearchContent && focusId.toLocaleLowerCase().includes(currentSearchContent);
+        const matchesFilter = selectedSearchFilters.length > 0 &&
+            focusTree.focuses[focusId]?.searchFilters.some(filter => selectedSearchFilters.includes(filter));
+        focusElement.style.outline = matchesSearch ? '1px solid #E33' : matchesFilter ? '2px solid #FC3' : '';
+        focusElement.style.background = matchesSearch ? 'rgba(255, 0, 0, 0.5)' :
+            matchesFilter ? 'rgba(255, 192, 0, 0.35)' : 'transparent';
+    }
 }
 
 const useConditionInFocus: boolean = (window as any).__featureflags.useConditionInFocus;
@@ -114,6 +128,7 @@ async function buildContent() {
     setupCheckedFocuses(focuses, focusTree);
     setupFocusDragging(focuses);
     refreshFocusSelection();
+    refreshFocusHighlights();
 }
 
 function calculateFocusAllowed(focusTree: FocusTree, allowBranchOptionsValue: Record<string, boolean>) {
@@ -200,6 +215,51 @@ function updateSelectedFocusTree(clearCondition: boolean) {
     if (clearCondition) {
         selectedFocusIds = [];
         setState({ selectedFocusIds });
+    }
+
+    updateFocusFilterControls();
+}
+
+function updateFocusFilterControls(): void {
+    const focusTree = focusTrees[selectedFocusTreeIndex];
+    const availableFilters = new Set(Object.values(focusTree.focuses).flatMap(focus => focus.searchFilters));
+    selectedSearchFilters = selectedSearchFilters.filter(filter => availableFilters.has(filter));
+    setState({ selectedSearchFilters });
+
+    let visibleButtonCount = 0;
+    for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>('.focus-filter'))) {
+        const filter = button.dataset.focusFilter ?? '';
+        button.hidden = !availableFilters.has(filter);
+        if (!button.hidden) {
+            visibleButtonCount++;
+        }
+        const selected = selectedSearchFilters.includes(filter);
+        button.setAttribute('aria-pressed', selected.toString());
+    }
+
+    const container = document.getElementById('focus-filter-container') as HTMLDivElement | null;
+    if (container) {
+        container.style.display = visibleButtonCount > 0 ? 'flex' : 'none';
+    }
+    refreshFocusHighlights();
+}
+
+function setupFocusFilterControls(): void {
+    for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>('.focus-filter'))) {
+        button.addEventListener('click', () => {
+            const filter = button.dataset.focusFilter;
+            if (!filter) {
+                return;
+            }
+
+            if (selectedSearchFilters.includes(filter)) {
+                selectedSearchFilters = selectedSearchFilters.filter(selected => selected !== filter);
+            } else {
+                selectedSearchFilters.push(filter);
+            }
+            setState({ selectedSearchFilters });
+            updateFocusFilterControls();
+        });
     }
 }
 
@@ -585,6 +645,7 @@ let retriggerSearch: () => void = () => {};
 window.addEventListener('load', tryRun(async function() {
     subscribePreviewLabelToggle();
     setupFocusBoxSelection();
+    setupFocusFilterControls();
 
     // Focuses
     const focusesElement = document.getElementById('focuses') as HTMLSelectElement | null;
@@ -696,5 +757,6 @@ window.addEventListener('load', tryRun(async function() {
     
     updateSelectedFocusTree(false);
     await buildContent();
+    retriggerSearch();
     scrollToState();
 }));

--- a/webviewsrc/focustree.ts
+++ b/webviewsrc/focustree.ts
@@ -30,7 +30,7 @@ function showBranch(visibility: boolean, optionClass: string) {
 };
 
 let currentSearchContent = '';
-let selectedSearchFilters: string[] = getState().selectedSearchFilters ?? [];
+let selectedSearchFilter: string | undefined = getState().selectedSearchFilter;
 
 function search(searchContent: string, navigate: boolean = true) {
     currentSearchContent = searchContent.toLocaleLowerCase();
@@ -58,8 +58,8 @@ function refreshFocusHighlights(): void {
     for (const focusElement of Array.from(document.querySelectorAll<HTMLDivElement>('.focus'))) {
         const focusId = focusElement.id.replace(/^focus_/, '');
         const matchesSearch = !!currentSearchContent && focusId.toLocaleLowerCase().includes(currentSearchContent);
-        const matchesFilter = selectedSearchFilters.length > 0 &&
-            focusTree.focuses[focusId]?.searchFilters.some(filter => selectedSearchFilters.includes(filter));
+        const matchesFilter = selectedSearchFilter !== undefined &&
+            focusTree.focuses[focusId]?.searchFilters.includes(selectedSearchFilter);
         focusElement.style.outline = matchesSearch ? '1px solid #E33' : matchesFilter ? '2px solid #FC3' : '';
         focusElement.style.background = matchesSearch ? 'rgba(255, 0, 0, 0.5)' :
             matchesFilter ? 'rgba(255, 192, 0, 0.35)' : 'transparent';
@@ -223,8 +223,10 @@ function updateSelectedFocusTree(clearCondition: boolean) {
 function updateFocusFilterControls(): void {
     const focusTree = focusTrees[selectedFocusTreeIndex];
     const availableFilters = new Set(Object.values(focusTree.focuses).flatMap(focus => focus.searchFilters));
-    selectedSearchFilters = selectedSearchFilters.filter(filter => availableFilters.has(filter));
-    setState({ selectedSearchFilters });
+    if (selectedSearchFilter && !availableFilters.has(selectedSearchFilter)) {
+        selectedSearchFilter = undefined;
+    }
+    setState({ selectedSearchFilter });
 
     let visibleButtonCount = 0;
     for (const button of Array.from(document.querySelectorAll<HTMLButtonElement>('.focus-filter'))) {
@@ -233,7 +235,7 @@ function updateFocusFilterControls(): void {
         if (!button.hidden) {
             visibleButtonCount++;
         }
-        const selected = selectedSearchFilters.includes(filter);
+        const selected = selectedSearchFilter === filter;
         button.setAttribute('aria-pressed', selected.toString());
     }
 
@@ -252,12 +254,7 @@ function setupFocusFilterControls(): void {
                 return;
             }
 
-            if (selectedSearchFilters.includes(filter)) {
-                selectedSearchFilters = selectedSearchFilters.filter(selected => selected !== filter);
-            } else {
-                selectedSearchFilters.push(filter);
-            }
-            setState({ selectedSearchFilters });
+            selectedSearchFilter = selectedSearchFilter === filter ? undefined : filter;
             updateFocusFilterControls();
         });
     }


### PR DESCRIPTION
国策树预览页面左下角，增加国策分类按钮单选选项。兼容左下角的大型分类图标+右上角小型分类图标，由于共用变量，所以归为一类放在预览页左下角