### PR TITLE
完善通用 GUI 控件解析与渲染

### DIFF
--- a/src/hoiformat/gui.ts
+++ b/src/hoiformat/gui.ts
@@ -35,6 +35,8 @@ export interface Background {
 export interface GuiTypes {
     containerwindowtype: ContainerWindowType[];
     windowtype: ContainerWindowType[];
+    scrollbartype: ScrollbarType[];
+    extendedscrollbartype: ExtendedScrollbarType[];
 }
 
 export interface ContainerWindowType {
@@ -43,6 +45,7 @@ export interface ContainerWindowType {
     orientation: Orientation;
     origo: Orientation;
     position: Position;
+    show_position: Position;
     size: ComplexSize;
     margin: Margin;
     background: Background;
@@ -55,6 +58,13 @@ export interface ContainerWindowType {
     buttontype: ButtonType[];
     checkboxtype: ButtonType[];
     guibuttontype: ButtonType[];
+    editboxtype: EditBoxType[];
+    overlappingelementsboxtype: OverlappingElementsBoxType[];
+    dropdownboxtype: DropdownBoxType[];
+    scrollbartype: ScrollbarType[];
+    extendedscrollbartype: ExtendedScrollbarType[];
+    smoothlistboxtype: SmoothListBoxType[];
+    listboxtype: ListBoxType[];
     _index: number;
     _token: Token;
 }
@@ -101,6 +111,7 @@ export interface InstantTextBoxType {
 
 export interface ButtonType {
     name: string;
+    parent: string;
     orientation: Orientation;
     position: Position;
     spritetype: string;
@@ -111,6 +122,107 @@ export interface ButtonType {
     buttonfont: string;
     scale: number;
     centerposition: boolean;
+    _index: number;
+    _token: Token;
+}
+
+export interface EditBoxType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    bordersize: Position;
+    font: string;
+    text: string;
+    format: Format;
+    _index: number;
+    _token: Token;
+}
+
+export interface OverlappingElementsBoxType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    format: Format;
+    spacing: number;
+    first_on_top: boolean;
+    _index: number;
+    _token: Token;
+}
+
+export interface SmoothListBoxType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    bordersize: Position;
+    spacing: number;
+    clipping: boolean;
+    scrollbartype: string;
+    _index: number;
+    _token: Token;
+}
+
+export interface ListBoxType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    bordersize: Position;
+    background: string;
+    offset: Position;
+    format: Format;
+    spacing: number;
+    horizontal: boolean;
+    scrollbartype: string;
+    _index: number;
+    _token: Token;
+}
+
+export interface DropdownBoxType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    containerwindowtype: ContainerWindowType[];
+    icontype: IconType[];
+    instanttextboxtype: InstantTextBoxType[];
+    buttontype: ButtonType[];
+    editboxtype: EditBoxType[];
+    expandbutton: ButtonType;
+    expandedwindow: ContainerWindowType;
+    _index: number;
+    _token: Token;
+}
+
+export interface ScrollbarType {
+    name: string;
+    orientation: Orientation;
+    position: Position;
+    size: Size;
+    horizontal: number;
+    guibuttontype: ButtonType[];
+    slider: string;
+    track: string;
+    leftbutton: string;
+    rightbutton: string;
+    _index: number;
+    _token: Token;
+}
+
+export interface ExtendedScrollbarType {
+    name: string;
+    orientation: Orientation;
+    origo: Orientation;
+    position: Position;
+    size: Size;
+    background: Background;
+    guibuttontype: ButtonType[];
+    slider: ButtonType;
+    track: ButtonType;
+    decreasebutton: ButtonType;
+    increasebutton: ButtonType;
     _index: number;
     _token: Token;
 }
@@ -181,6 +293,7 @@ const instantTextBoxTypeSchema: SchemaDef<InstantTextBoxType> = {
 
 const buttonTypeSchema: SchemaDef<ButtonType> = {
     name: 'string',
+    parent: 'string',
     spritetype: 'string',
     quadtexturesprite: 'string',
     position: positionSchema,
@@ -193,12 +306,121 @@ const buttonTypeSchema: SchemaDef<ButtonType> = {
     centerposition: 'boolean',
 };
 
+const editBoxTypeSchema: SchemaDef<EditBoxType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    bordersize: positionSchema,
+    font: 'string',
+    text: 'string',
+    format: 'stringignorecase',
+};
+
+const overlappingElementsBoxTypeSchema: SchemaDef<OverlappingElementsBoxType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    format: 'stringignorecase',
+    spacing: 'number',
+    first_on_top: 'boolean',
+};
+
+const smoothListBoxTypeSchema: SchemaDef<SmoothListBoxType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    bordersize: positionSchema,
+    spacing: 'number',
+    clipping: 'boolean',
+    scrollbartype: 'string',
+};
+
+const listBoxTypeSchema: SchemaDef<ListBoxType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    bordersize: positionSchema,
+    background: 'string',
+    offset: positionSchema,
+    format: 'stringignorecase',
+    spacing: 'number',
+    horizontal: 'boolean',
+    scrollbartype: 'string',
+};
+
+const dropdownBoxTypeSchema: SchemaDef<DropdownBoxType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    containerwindowtype: {
+        _innerType: undefined as any,
+        _type: 'array',
+    },
+    icontype: {
+        _innerType: iconTypeSchema,
+        _type: 'array',
+    },
+    instanttextboxtype: {
+        _innerType: instantTextBoxTypeSchema,
+        _type: 'array',
+    },
+    buttontype: {
+        _innerType: buttonTypeSchema,
+        _type: 'array',
+    },
+    editboxtype: {
+        _innerType: editBoxTypeSchema,
+        _type: 'array',
+    },
+    expandbutton: buttonTypeSchema,
+    expandedwindow: undefined as any,
+};
+
+const scrollbarTypeSchema: SchemaDef<ScrollbarType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    horizontal: 'number',
+    guibuttontype: {
+        _innerType: buttonTypeSchema,
+        _type: 'array',
+    },
+    slider: 'string',
+    track: 'string',
+    leftbutton: 'string',
+    rightbutton: 'string',
+};
+
+const extendedScrollbarTypeSchema: SchemaDef<ExtendedScrollbarType> = {
+    name: 'string',
+    orientation: 'stringignorecase',
+    origo: 'stringignorecase',
+    position: positionSchema,
+    size: sizeSchema,
+    background: backgroundSchema,
+    guibuttontype: {
+        _innerType: buttonTypeSchema,
+        _type: 'array',
+    },
+    slider: buttonTypeSchema,
+    track: buttonTypeSchema,
+    decreasebutton: buttonTypeSchema,
+    increasebutton: buttonTypeSchema,
+};
+
 const containerWindowTypeSchema: SchemaDef<ContainerWindowType> = {
     name: 'string',
     fullscreen: 'boolean',
     orientation: 'stringignorecase',
     origo: 'stringignorecase',
     position: positionSchema,
+    show_position: positionSchema,
     size: complexSizeSchema,
     margin: marginSchema,
     background: backgroundSchema,
@@ -238,10 +460,40 @@ const containerWindowTypeSchema: SchemaDef<ContainerWindowType> = {
         _innerType: buttonTypeSchema,
         _type: 'array',
     },
+    editboxtype: {
+        _innerType: editBoxTypeSchema,
+        _type: 'array',
+    },
+    overlappingelementsboxtype: {
+        _innerType: overlappingElementsBoxTypeSchema,
+        _type: 'array',
+    },
+    dropdownboxtype: {
+        _innerType: dropdownBoxTypeSchema,
+        _type: 'array',
+    },
+    scrollbartype: {
+        _innerType: scrollbarTypeSchema,
+        _type: 'array',
+    },
+    extendedscrollbartype: {
+        _innerType: extendedScrollbarTypeSchema,
+        _type: 'array',
+    },
+    smoothlistboxtype: {
+        _innerType: smoothListBoxTypeSchema,
+        _type: 'array',
+    },
+    listboxtype: {
+        _innerType: listBoxTypeSchema,
+        _type: 'array',
+    },
 };
 
 containerWindowTypeSchema.containerwindowtype._innerType = containerWindowTypeSchema;
 containerWindowTypeSchema.windowtype._innerType = containerWindowTypeSchema;
+dropdownBoxTypeSchema.containerwindowtype._innerType = containerWindowTypeSchema;
+dropdownBoxTypeSchema.expandedwindow = containerWindowTypeSchema;
 
 const guiTypesSchema: SchemaDef<GuiTypes> = {
     containerwindowtype: {
@@ -250,6 +502,14 @@ const guiTypesSchema: SchemaDef<GuiTypes> = {
     },
     windowtype: {
         _innerType: containerWindowTypeSchema,
+        _type: 'array',
+    },
+    scrollbartype: {
+        _innerType: scrollbarTypeSchema,
+        _type: 'array',
+    },
+    extendedscrollbartype: {
+        _innerType: extendedScrollbarTypeSchema,
         _type: 'array',
     },
 };

--- a/src/previewdef/gui/contentbuilder.ts
+++ b/src/previewdef/gui/contentbuilder.ts
@@ -165,9 +165,10 @@ async function renderSingleContainerWindow(
         }
     }
 
+    const visiblePosition = containerWindow.show_position ?? containerWindow.position;
     const position = containerWindow.fullscreen
         ? { x: toNumberLike(0), y: toNumberLike(0) }
-        : containerWindow.position ? { ...containerWindow.position } : { x: undefined, y: undefined };
+        : visiblePosition ? { ...visiblePosition } : { x: undefined, y: undefined };
     if (position.x?._value !== undefined && position.x?._value < 0) {
         position.x = { ...position.x, _value: 0 };
     }
@@ -182,6 +183,7 @@ async function renderSingleContainerWindow(
                 ...commonOptions,
                 classNames: 'childcontainerwindow_' + normalizeForStyle(childContainerWindow.name ?? ''),
                 enableNavigator: true,
+                useShowPosition: true,
                 onRenderChild,
             });
         }

--- a/src/util/hoi4gui/button.ts
+++ b/src/util/hoi4gui/button.ts
@@ -26,6 +26,7 @@ export async function renderButton(button: HOIPartial<ButtonType>, parentInfo: P
     start="${button._token?.start}"
     end="${button._token?.end}"
     class="
+        ${options?.classNames ? options.classNames : ''}
         ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
         ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
         ${options.styleTable.oneTimeStyle('button', () => `

--- a/src/util/hoi4gui/button.ts
+++ b/src/util/hoi4gui/button.ts
@@ -26,7 +26,7 @@ export async function renderButton(button: HOIPartial<ButtonType>, parentInfo: P
     start="${button._token?.start}"
     end="${button._token?.end}"
     class="
-        ${options?.classNames ? options.classNames : ''}
+        ${options.classNames ? options.classNames : ''}
         ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
         ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
         ${options.styleTable.oneTimeStyle('button', () => `

--- a/src/util/hoi4gui/containerwindow.ts
+++ b/src/util/hoi4gui/containerwindow.ts
@@ -3,9 +3,26 @@ import { calculateBBox, normalizeMargin, ParentInfo, removeHtmlOptions } from '.
 import { renderIcon } from './icon';
 import { renderInstantTextBox } from './instanttextbox';
 import { renderGridBox } from './gridbox';
-import { ButtonType, ContainerWindowType, GridBoxType, IconType, InstantTextBoxType } from '../../hoiformat/gui';
+import {
+    ButtonType,
+    ContainerWindowType,
+    DropdownBoxType,
+    EditBoxType,
+    ExtendedScrollbarType,
+    GridBoxType,
+    IconType,
+    InstantTextBoxType,
+    ListBoxType,
+    OverlappingElementsBoxType,
+    ScrollbarType,
+    SmoothListBoxType,
+} from '../../hoiformat/gui';
 import { renderBackground, RenderNodeCommonOptions } from './nodecommon';
 import { renderButton } from './button';
+import { renderDropdownBox } from './dropdownbox';
+import { renderEditBox } from './editbox';
+import { renderListBox, renderOverlappingElementsBox, renderSmoothListBox } from './layoutbox';
+import { renderExtendedScrollbar, renderScrollbar } from './scrollbar';
 
 export interface RenderChildTypeMap {
     containerwindow: HOIPartial<ContainerWindowType>;
@@ -13,16 +30,33 @@ export interface RenderChildTypeMap {
     icon: HOIPartial<IconType>;
     instanttextbox: HOIPartial<InstantTextBoxType>;
     button: HOIPartial<ButtonType>;
+    editbox: HOIPartial<EditBoxType>;
+    dropdownbox: HOIPartial<DropdownBoxType>;
+    overlappingelementsbox: HOIPartial<OverlappingElementsBoxType>;
+    smoothlistbox: HOIPartial<SmoothListBoxType>;
+    listbox: HOIPartial<ListBoxType>;
+    scrollbar: HOIPartial<ScrollbarType>;
+    extendedscrollbar: HOIPartial<ExtendedScrollbarType>;
 }
 
 export interface RenderContainerWindowOptions extends RenderNodeCommonOptions {
     noSize?: boolean;
     ignorePosition?: boolean;
+    useShowPosition?: boolean;
     onRenderChild?<T extends keyof RenderChildTypeMap>(type: T, child: RenderChildTypeMap[T], parentInfo: ParentInfo): Promise<string | undefined>;
 }
 
+interface CommonChildCollection {
+    containerwindowtype: HOIPartial<ContainerWindowType>[];
+    icontype: HOIPartial<IconType>[];
+    instanttextboxtype: HOIPartial<InstantTextBoxType>[];
+    buttontype: HOIPartial<ButtonType>[];
+    editboxtype: HOIPartial<EditBoxType>[];
+}
+
 export async function renderContainerWindow(containerWindow: HOIPartial<ContainerWindowType>, parentInfo: ParentInfo, options: RenderContainerWindowOptions): Promise<string> {
-    const [x, y, width, height, orientation] = calculateBBox(containerWindow, parentInfo);
+    const position = options.useShowPosition ? containerWindow.show_position ?? containerWindow.position : containerWindow.position;
+    const [x, y, width, height, orientation] = calculateBBox({ ...containerWindow, position }, parentInfo);
     const size = { width, height };
     const margin = normalizeMargin(containerWindow.margin, size);
     const myInfo: ParentInfo = {
@@ -66,24 +100,109 @@ export async function renderContainerWindow(containerWindow: HOIPartial<Containe
 }
 
 export async function renderContainerWindowChildren(containerWindow: HOIPartial<ContainerWindowType>, myInfo: ParentInfo, options: RenderContainerWindowOptions): Promise<string> {
-    const containerWindowChildren = [...containerWindow.containerwindowtype, ...containerWindow.windowtype]
-        .map(c => onRenderChildOrDefault(options.onRenderChild, 'containerwindow', c, myInfo, c1 => renderContainerWindow(c1, myInfo, removeHtmlOptions(options))));
+    const commonChildren = renderCommonChildren({
+        containerwindowtype: [...containerWindow.containerwindowtype, ...containerWindow.windowtype],
+        icontype: containerWindow.icontype,
+        instanttextboxtype: [...containerWindow.instanttextboxtype, ...containerWindow.textboxtype],
+        buttontype: [...containerWindow.buttontype, ...containerWindow.checkboxtype, ...containerWindow.guibuttontype],
+        editboxtype: containerWindow.editboxtype,
+    }, myInfo, options);
     const gridboxChildren = containerWindow.gridboxtype
         .map(c => onRenderChildOrDefault(options.onRenderChild, 'gridbox', c, myInfo, c1 => renderGridBox(c1, myInfo, removeHtmlOptions({ ...options, items: {} }))));
-    const iconChildren = containerWindow.icontype
-        .map(c => onRenderChildOrDefault(options.onRenderChild, 'icon', c, myInfo, c1 => renderIcon(c1, myInfo, removeHtmlOptions(options))));
-    const instantTextBoxChildren = [...containerWindow.instanttextboxtype, ...containerWindow.textboxtype]
-        .map(c => onRenderChildOrDefault(options.onRenderChild, 'instanttextbox', c, myInfo, c1 => renderInstantTextBox(c1, myInfo, removeHtmlOptions(options))));
-    const buttonChildren = [...containerWindow.buttontype, ...containerWindow.checkboxtype, ...containerWindow.guibuttontype]
-        .map(c => onRenderChildOrDefault(options.onRenderChild, 'button', c, myInfo, c1 => renderButton(c1, myInfo, removeHtmlOptions(options))));
+    const dropdownBoxChildren = containerWindow.dropdownboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'dropdownbox', c, myInfo, c1 => renderDropdownBox(c1, myInfo, {
+            ...removeHtmlOptions(options),
+            renderChildren: (dropdownBox, parentInfo) => renderDropdownBoxChildren(dropdownBox, parentInfo, options),
+        })));
+    const overlappingElementsBoxChildren = containerWindow.overlappingelementsboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'overlappingelementsbox', c, myInfo, c1 => renderOverlappingElementsBox(c1, myInfo, removeHtmlOptions(options))));
+    const smoothListBoxChildren = containerWindow.smoothlistboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'smoothlistbox', c, myInfo, c1 => renderSmoothListBox(c1, myInfo, removeHtmlOptions(options))));
+    const listBoxChildren = containerWindow.listboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'listbox', c, myInfo, c1 => renderListBox(c1, myInfo, removeHtmlOptions(options))));
+    const scrollbarChildren = containerWindow.scrollbartype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'scrollbar', c, myInfo, c1 => renderScrollbar(c1, myInfo, removeHtmlOptions(options))));
+    const extendedScrollbarChildren = containerWindow.extendedscrollbartype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'extendedscrollbar', c, myInfo, c1 => renderExtendedScrollbar(c1, myInfo, removeHtmlOptions(options))));
 
-    const result = (await Promise.all([
-        ...containerWindowChildren,
+    return await joinChildrenInOrder([
+        ...commonChildren,
         ...gridboxChildren,
+        ...dropdownBoxChildren,
+        ...overlappingElementsBoxChildren,
+        ...smoothListBoxChildren,
+        ...listBoxChildren,
+        ...scrollbarChildren,
+        ...extendedScrollbarChildren,
+    ]);
+}
+
+async function renderDropdownBoxChildren(dropdownBox: HOIPartial<DropdownBoxType>, myInfo: ParentInfo, options: RenderContainerWindowOptions): Promise<string> {
+    const children = renderCommonChildren(dropdownBox, myInfo, options);
+    const expandButton = dropdownBox.expandbutton ? onRenderChildOrDefault(
+        options.onRenderChild,
+        'button',
+        dropdownBox.expandbutton,
+        myInfo,
+        button => renderButton(button, myInfo, {
+            ...removeHtmlOptions(options),
+            classNames: 'gui-dropdown-button',
+            enableNavigator: undefined,
+        }),
+    ) : undefined;
+    const expandedWindow = dropdownBox.expandedwindow ?
+        renderDropdownExpandedWindow(dropdownBox.expandedwindow, myInfo, options) :
+        undefined;
+
+    return await joinChildrenInOrder([
+        ...children,
+        ...(expandButton ? [expandButton] : []),
+        ...(expandedWindow ? [expandedWindow] : []),
+    ]);
+}
+
+function renderCommonChildren(
+    children: CommonChildCollection,
+    myInfo: ParentInfo,
+    options: RenderContainerWindowOptions,
+): Promise<[number, string]>[] {
+    const containerWindowChildren = children.containerwindowtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'containerwindow', c, myInfo, c1 => renderContainerWindow(c1, myInfo, removeHtmlOptions(options))));
+    const iconChildren = children.icontype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'icon', c, myInfo, c1 => renderIcon(c1, myInfo, removeHtmlOptions(options))));
+    const instantTextBoxChildren = children.instanttextboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'instanttextbox', c, myInfo, c1 => renderInstantTextBox(c1, myInfo, removeHtmlOptions(options))));
+    const buttonChildren = children.buttontype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'button', c, myInfo, c1 => renderButton(c1, myInfo, removeHtmlOptions(options))));
+    const editBoxChildren = children.editboxtype
+        .map(c => onRenderChildOrDefault(options.onRenderChild, 'editbox', c, myInfo, c1 => renderEditBox(c1, myInfo, removeHtmlOptions(options))));
+
+    return [
+        ...containerWindowChildren,
         ...iconChildren,
         ...instantTextBoxChildren,
         ...buttonChildren,
-    ]));
+        ...editBoxChildren,
+    ];
+}
+
+async function renderDropdownExpandedWindow(
+    expandedWindow: HOIPartial<ContainerWindowType>,
+    myInfo: ParentInfo,
+    options: RenderContainerWindowOptions,
+): Promise<[number, string]> {
+    const [sourceOrder, content] = await onRenderChildOrDefault(
+        options.onRenderChild,
+        'containerwindow',
+        expandedWindow,
+        myInfo,
+        child => renderContainerWindow(child, myInfo, { ...removeHtmlOptions(options), useShowPosition: true }),
+    );
+    return [sourceOrder, `<div class="gui-dropdown-expanded" hidden>${content}</div>`];
+}
+
+async function joinChildrenInOrder(children: Promise<[number, string]>[]): Promise<string> {
+    const result = await Promise.all(children);
     result.sort((a, b) => a[0] - b[0]);
     return result.map(v => v[1]).join('');
 }
@@ -101,7 +220,7 @@ export async function onRenderChildOrDefault<T extends keyof RenderChildTypeMap>
     }
 
     return [
-        child._index || 0,
+        child._token?.start ?? child._index ?? 0,
         result !== undefined ? result : await defaultRenderer(child),
     ];
 }

--- a/src/util/hoi4gui/containerwindow.ts
+++ b/src/util/hoi4gui/containerwindow.ts
@@ -220,7 +220,7 @@ export async function onRenderChildOrDefault<T extends keyof RenderChildTypeMap>
     }
 
     return [
-        child._token?.start ?? child._index ?? 0,
+        child._token?.start ?? 0,
         result !== undefined ? result : await defaultRenderer(child),
     ];
 }

--- a/src/util/hoi4gui/dropdownbox.ts
+++ b/src/util/hoi4gui/dropdownbox.ts
@@ -1,0 +1,35 @@
+import { DropdownBoxType } from '../../hoiformat/gui';
+import { HOIPartial } from '../../hoiformat/schema';
+import { calculateBBox, ParentInfo } from './common';
+import { RenderNodeCommonOptions } from './nodecommon';
+
+export interface RenderDropdownBoxOptions extends RenderNodeCommonOptions {
+    renderChildren(dropdownBox: HOIPartial<DropdownBoxType>, parentInfo: ParentInfo): Promise<string>;
+}
+
+export async function renderDropdownBox(
+    dropdownBox: HOIPartial<DropdownBoxType>,
+    parentInfo: ParentInfo,
+    options: RenderDropdownBoxOptions,
+): Promise<string> {
+    const [x, y, width, height, orientation] = calculateBBox(dropdownBox, parentInfo);
+    const children = await options.renderChildren(dropdownBox, { size: { width, height }, orientation });
+
+    return `<div
+    start="${dropdownBox._token?.start}"
+    end="${dropdownBox._token?.end}"
+    class="
+        gui-dropdown
+        ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
+        ${options.styleTable.oneTimeStyle('dropdownbox', () => `
+            left: ${x}px;
+            top: ${y}px;
+            width: ${width}px;
+            height: ${height}px;
+            overflow: visible;
+        `)}
+        ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
+    ">
+        ${children}
+    </div>`;
+}

--- a/src/util/hoi4gui/editbox.ts
+++ b/src/util/hoi4gui/editbox.ts
@@ -1,0 +1,44 @@
+import { EditBoxType } from '../../hoiformat/gui';
+import { HOIPartial, toNumberLike, toStringAsSymbolIgnoreCase } from '../../hoiformat/schema';
+import { calculateBBox, ParentInfo } from './common';
+import { renderInstantTextBox } from './instanttextbox';
+import { RenderNodeCommonOptions } from './nodecommon';
+
+export interface RenderEditBoxOptions extends RenderNodeCommonOptions {
+}
+
+export async function renderEditBox(editBox: HOIPartial<EditBoxType>, parentInfo: ParentInfo, options: RenderEditBoxOptions): Promise<string> {
+    const [x, y, width, height, orientation] = calculateBBox(editBox, parentInfo);
+    const content = await renderInstantTextBox({
+        name: editBox.name,
+        orientation: toStringAsSymbolIgnoreCase('upper_left'),
+        position: { x: toNumberLike(0), y: toNumberLike(0) },
+        bordersize: editBox.bordersize,
+        maxwidth: toNumberLike(width),
+        maxheight: toNumberLike(height),
+        font: editBox.font,
+        text: editBox.text,
+        format: editBox.format,
+        vertical_alignment: 'center',
+        _index: editBox._index,
+        _token: editBox._token,
+    }, { size: { width, height }, orientation }, { ...options, enableNavigator: undefined });
+
+    return `<div
+    start="${editBox._token?.start}"
+    end="${editBox._token?.end}"
+    class="
+        ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
+        ${options.styleTable.style('borderBox', () => `box-sizing: border-box;`)}
+        ${options.styleTable.oneTimeStyle('editbox', () => `
+            left: ${x}px;
+            top: ${y}px;
+            width: ${width}px;
+            height: ${height}px;
+            overflow: hidden;
+        `)}
+        ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
+    ">
+        ${content}
+    </div>`;
+}

--- a/src/util/hoi4gui/layoutbox.ts
+++ b/src/util/hoi4gui/layoutbox.ts
@@ -1,0 +1,44 @@
+import { ListBoxType, OverlappingElementsBoxType, SmoothListBoxType } from '../../hoiformat/gui';
+import { HOIPartial } from '../../hoiformat/schema';
+import { calculateBBox, ParentInfo } from './common';
+import { RenderNodeCommonOptions, renderSprite } from './nodecommon';
+
+export interface RenderLayoutBoxOptions extends RenderNodeCommonOptions {
+}
+
+type LayoutBox = HOIPartial<ListBoxType> | HOIPartial<OverlappingElementsBoxType> | HOIPartial<SmoothListBoxType>;
+
+export async function renderListBox(listBox: HOIPartial<ListBoxType>, parentInfo: ParentInfo, options: RenderLayoutBoxOptions): Promise<string> {
+    return await renderLayoutBox(listBox, parentInfo, options, listBox.background);
+}
+
+export async function renderOverlappingElementsBox(overlappingElementsBox: HOIPartial<OverlappingElementsBoxType>, parentInfo: ParentInfo, options: RenderLayoutBoxOptions): Promise<string> {
+    return await renderLayoutBox(overlappingElementsBox, parentInfo, options);
+}
+
+export async function renderSmoothListBox(smoothListBox: HOIPartial<SmoothListBoxType>, parentInfo: ParentInfo, options: RenderLayoutBoxOptions): Promise<string> {
+    return await renderLayoutBox(smoothListBox, parentInfo, options);
+}
+
+async function renderLayoutBox(layoutBox: LayoutBox, parentInfo: ParentInfo, options: RenderLayoutBoxOptions, backgroundSprite?: string): Promise<string> {
+    const [x, y, width, height] = calculateBBox(layoutBox, parentInfo);
+    const backgroundImage = options.getSprite && backgroundSprite ? await options.getSprite(backgroundSprite, 'bg', layoutBox.name) : undefined;
+    const background = backgroundImage ? renderSprite({ x: 0, y: 0 }, { width, height }, backgroundImage, 0, 1, options) : '';
+
+    return `<div
+    start="${layoutBox._token?.start}"
+    end="${layoutBox._token?.end}"
+    class="
+        ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
+        ${options.styleTable.style('borderBox', () => `box-sizing: border-box;`)}
+        ${options.styleTable.oneTimeStyle('layoutbox', () => `
+            left: ${x}px;
+            top: ${y}px;
+            width: ${width}px;
+            height: ${height}px;
+        `)}
+        ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
+    ">
+        ${background}
+    </div>`;
+}

--- a/src/util/hoi4gui/scrollbar.ts
+++ b/src/util/hoi4gui/scrollbar.ts
@@ -1,0 +1,118 @@
+import { ButtonType, ExtendedScrollbarType, ScrollbarType } from '../../hoiformat/gui';
+import { HOIPartial, toNumberLike, toStringAsSymbolIgnoreCase } from '../../hoiformat/schema';
+import { renderButton } from './button';
+import { calculateBBox, ParentInfo, removeHtmlOptions } from './common';
+import { renderBackground, RenderNodeCommonOptions } from './nodecommon';
+
+export interface RenderScrollbarOptions extends RenderNodeCommonOptions {
+}
+
+type Scrollbar = HOIPartial<ScrollbarType> | HOIPartial<ExtendedScrollbarType>;
+
+export async function renderScrollbar(scrollbar: HOIPartial<ScrollbarType>, parentInfo: ParentInfo, options: RenderScrollbarOptions): Promise<string> {
+    return await renderScrollbarCommon(scrollbar, parentInfo, options, async myInfo => {
+        const buttonsByName = new Map(scrollbar.guibuttontype
+            .filter(button => button.name !== undefined)
+            .map(button => [button.name as string, button]));
+        const buttons = scrollbar.guibuttontype.map(button => normalizeScrollbarButton(button, buttonsByName, myInfo, scrollbar.horizontal));
+        return { background: '', buttons: await renderButtons(buttons, myInfo, options) };
+    });
+}
+
+export async function renderExtendedScrollbar(scrollbar: HOIPartial<ExtendedScrollbarType>, parentInfo: ParentInfo, options: RenderScrollbarOptions): Promise<string> {
+    return await renderScrollbarCommon(scrollbar, parentInfo, options, async myInfo => {
+        const buttons = [
+            ...scrollbar.guibuttontype,
+            scrollbar.slider,
+            scrollbar.track,
+            scrollbar.decreasebutton,
+            scrollbar.increasebutton,
+        ].filter(hasRenderableButton);
+        return {
+            background: await renderBackground(scrollbar.background, myInfo, options),
+            buttons: await renderButtons(buttons, myInfo, options),
+        };
+    });
+}
+
+async function renderScrollbarCommon(
+    scrollbar: Scrollbar,
+    parentInfo: ParentInfo,
+    options: RenderScrollbarOptions,
+    renderContents: (parentInfo: ParentInfo) => Promise<{ background: string; buttons: string }>,
+): Promise<string> {
+    const [x, y, width, height, orientation] = calculateBBox(scrollbar, parentInfo);
+    const contents = await renderContents({ size: { width, height }, orientation });
+
+    return `<div
+    start="${scrollbar._token?.start}"
+    end="${scrollbar._token?.end}"
+    class="
+        ${options.styleTable.style('positionAbsolute', () => `position: absolute;`)}
+        ${options.styleTable.style('borderBox', () => `box-sizing: border-box;`)}
+        ${options.styleTable.oneTimeStyle('scrollbar', () => `
+            left: ${x}px;
+            top: ${y}px;
+            width: ${width}px;
+            height: ${height}px;
+        `)}
+        ${options.enableNavigator ? 'navigator navigator-highlight' : ''}
+    ">
+        ${contents.background}
+        ${contents.buttons}
+    </div>`;
+}
+
+async function renderButtons(buttons: HOIPartial<ButtonType>[], parentInfo: ParentInfo, options: RenderScrollbarOptions): Promise<string> {
+    const sortedButtons = [...buttons].sort(compareSourceOrder);
+    return (await Promise.all(sortedButtons.map(button => renderButton(button, parentInfo, removeHtmlOptions(options))))).join('');
+}
+
+function normalizeScrollbarButton(
+    button: HOIPartial<ButtonType>,
+    buttonsByName: Map<string, HOIPartial<ButtonType>>,
+    parentInfo: ParentInfo,
+    horizontal: number | undefined,
+): HOIPartial<ButtonType> {
+    const [canonicalX, canonicalY] = calculateScrollbarButtonPosition(button, buttonsByName, parentInfo, new Set(button.name ? [button.name] : []));
+    const [x, y] = (horizontal ?? 0) !== 0 ? [canonicalY, canonicalX] : [canonicalX, canonicalY];
+    return {
+        ...button,
+        orientation: toStringAsSymbolIgnoreCase('upper_left'),
+        position: { x: toNumberLike(x), y: toNumberLike(y) },
+    };
+}
+
+function calculateScrollbarButtonPosition(
+    button: HOIPartial<ButtonType>,
+    buttonsByName: Map<string, HOIPartial<ButtonType>>,
+    parentInfo: ParentInfo,
+    visited: Set<string>,
+): [number, number] {
+    const [x, y] = calculateBBox(button, parentInfo);
+    const parentName = button.parent;
+    if (!parentName || visited.has(parentName)) {
+        return [x, y];
+    }
+
+    const parent = buttonsByName.get(parentName);
+    if (!parent) {
+        return [x, y];
+    }
+
+    const nextVisited = new Set(visited);
+    if (button.name) {
+        nextVisited.add(button.name);
+    }
+    const [parentX, parentY] = calculateScrollbarButtonPosition(parent, buttonsByName, parentInfo, nextVisited);
+    return [x + parentX, y + parentY];
+}
+
+function compareSourceOrder(a: HOIPartial<ButtonType>, b: HOIPartial<ButtonType>): number {
+    return (a._token?.start ?? a._index ?? 0) - (b._token?.start ?? b._index ?? 0);
+}
+
+function hasRenderableButton(button: HOIPartial<ButtonType> | undefined): button is HOIPartial<ButtonType> {
+    return button !== undefined &&
+        (button.name !== undefined || button.spritetype !== undefined || button.quadtexturesprite !== undefined);
+}

--- a/test/suite/gui/containerwindow.test.ts
+++ b/test/suite/gui/containerwindow.test.ts
@@ -1,3 +1,4 @@
+import '../../../src/indexing/indexmanager';
 import * as assert from 'assert';
 import { ContainerWindowType, GuiFile, guiFileSchema } from '../../../src/hoiformat/gui';
 import { parseHoi4File } from '../../../src/hoiformat/hoiparser';

--- a/test/suite/gui/containerwindow.test.ts
+++ b/test/suite/gui/containerwindow.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import { ContainerWindowType, GuiFile, guiFileSchema } from '../../../src/hoiformat/gui';
+import { parseHoi4File } from '../../../src/hoiformat/hoiparser';
+import { HOIPartial, convertNodeToJson } from '../../../src/hoiformat/schema';
+import { Sprite } from '../../../src/util/image/sprite';
+import {
+    RenderContainerWindowOptions,
+    renderContainerWindow,
+    renderContainerWindowChildren,
+} from '../../../src/util/hoi4gui/containerwindow';
+import { StyleTable } from '../../../src/util/styletable';
+
+suite('GUI container window rendering', () => {
+    test('keeps source order across all supported child types', async () => {
+        const container = parseContainerWindow(`
+            buttonType = { name = "button" }
+            editBoxType = { name = "edit" }
+            dropDownBoxType = { name = "dropdown" }
+            overlappingElementsBoxType = { name = "overlap" }
+            smoothListBoxType = { name = "smooth" }
+            listBoxType = { name = "list" }
+            scrollbarType = { name = "scrollbar" }
+            extendedScrollbarType = { name = "extended" }
+            iconType = { name = "icon" }
+            instantTextBoxType = { name = "text" }
+            gridBoxType = { name = "grid" }
+            containerWindowType = { name = "container" }
+        `);
+        const onRenderChild: RenderContainerWindowOptions['onRenderChild'] = async (type, child) =>
+            `[${type}:${child.name}]`;
+
+        const rendered = await renderContainerWindowChildren(container, {
+            size: { width: 500, height: 400 },
+            orientation: 'upper_left',
+        }, {
+            styleTable: new StyleTable(),
+            onRenderChild,
+        });
+
+        assert.deepStrictEqual(rendered.match(/\[[^\]]+\]/g), [
+            '[button:button]',
+            '[editbox:edit]',
+            '[dropdownbox:dropdown]',
+            '[overlappingelementsbox:overlap]',
+            '[smoothlistbox:smooth]',
+            '[listbox:list]',
+            '[scrollbar:scrollbar]',
+            '[extendedscrollbar:extended]',
+            '[icon:icon]',
+            '[instanttextbox:text]',
+            '[gridbox:grid]',
+            '[containerwindow:container]',
+        ]);
+    });
+
+    test('keeps source order inside dropdown boxes', async () => {
+        const container = parseContainerWindow(`
+            dropDownBoxType = {
+                name = "dropdown"
+                buttonType = { name = "first" }
+                expandedWindow = { name = "expanded" }
+                iconType = { name = "third" }
+                expandButton = { name = "expand" }
+                editBoxType = { name = "last" }
+            }
+        `);
+        const onRenderChild: RenderContainerWindowOptions['onRenderChild'] = async (type, child) =>
+            type === 'dropdownbox' ? undefined : `[${child.name}]`;
+
+        const rendered = await renderContainerWindowChildren(container, {
+            size: { width: 500, height: 400 },
+            orientation: 'upper_left',
+        }, {
+            styleTable: new StyleTable(),
+            onRenderChild,
+        });
+
+        assert.deepStrictEqual(rendered.match(/\[[^\]]+\]/g), [
+            '[first]',
+            '[expanded]',
+            '[third]',
+            '[expand]',
+            '[last]',
+        ]);
+    });
+
+    test('renders generic controls', async () => {
+        const container = parseContainerWindow(`
+            editBoxType = { name = "edit" position = { x = 5 y = 6 } size = { x = 100 y = 24 } borderSize = { x = 3 y = 2 } text = "value" }
+            dropDownBoxType = {
+                name = "dropdown" position = { x = 10 y = 40 } size = { x = 180 y = 30 }
+                editBoxType = { name = "dropdown_edit" position = { x = 4 y = 3 } size = { x = 120 y = 24 } text = "selected" }
+                expandButton = { name = "expand" spriteType = "GFX_button" }
+                expandedWindow = { name = "expanded" position = { x = -200 y = -200 } show_position = { x = 17 y = 29 } size = { x = 180 y = 100 } }
+            }
+            listBoxType = { name = "list" position = { x = 10 y = 80 } size = { x = 180 y = 30 } background = "GFX_list" }
+            scrollbarType = {
+                name = "scrollbar" position = { x = 390 y = 10 } size = { x = 16 y = 120 } horizontal = 1
+                guiButtonType = { name = "slider" spriteType = "GFX_slider" position = { x = -12 y = 0 } }
+                guiButtonType = { parent = "slider" name = "down" spriteType = "GFX_down" position = { x = 0 y = 120 } }
+            }
+        `);
+        const styleTable = new StyleTable();
+
+        const rendered = await renderContainerWindow(container, {
+            size: { width: 500, height: 400 },
+            orientation: 'upper_left',
+        }, {
+            styleTable,
+            enableNavigator: true,
+            getSprite: async () => ({
+                id: 'test',
+                width: 10,
+                height: 10,
+                frames: [{ uri: 'data:image/png;base64,' }],
+            }) as unknown as Sprite,
+        });
+        const styles = styleTable.toStyleElement('nonce');
+
+        assert.ok(rendered.includes('value'));
+        assert.ok(rendered.includes('gui-dropdown-button'));
+        assert.ok(rendered.includes('gui-dropdown-expanded" hidden'));
+        assert.match(styles, /left: 17px;\s+top: 29px;/);
+        assert.match(styles, /left: 10px;\s+top: 80px;\s+width: 180px;\s+height: 30px;/);
+        assert.match(styles, /left: 390px;\s+top: 10px;\s+width: 16px;\s+height: 120px;/);
+        assert.match(styles, /left: 120px;\s+top: -12px;/);
+    });
+});
+
+function parseContainerWindow(children: string): HOIPartial<ContainerWindowType> {
+    const gui = convertNodeToJson<GuiFile>(parseHoi4File(`
+        guiTypes = {
+            containerWindowType = {
+                name = "root"
+                size = { x = 500 y = 400 }
+                ${children}
+            }
+        }
+    `), guiFileSchema);
+
+    return gui.guitypes[0].containerwindowtype[0];
+}

--- a/test/suite/hoiformat/gui.test.ts
+++ b/test/suite/hoiformat/gui.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import { GuiFile } from '../../../src/hoiformat/gui';
+import { GuiFile, guiFileSchema } from '../../../src/hoiformat/gui';
 import { parseHoi4File } from '../../../src/hoiformat/hoiparser';
-import { guiFileSchema } from '../../../src/hoiformat/gui';
 import { convertNodeToJson } from '../../../src/hoiformat/schema';
 
 suite('GUI fullScreen', () => {
@@ -17,5 +16,60 @@ suite('GUI fullScreen', () => {
         `), guiFileSchema);
 
         assert.strictEqual(gui.guitypes[0].windowtype[0].fullscreen, true);
+    });
+});
+
+suite('GUI common controls', () => {
+    test('parses common layout and input controls', () => {
+        const gui = convertNodeToJson<GuiFile>(parseHoi4File(`
+            guiTypes = {
+                containerWindowType = {
+                    name = "controls"
+                    size = { x = 500 y = 400 }
+                    editBoxType = { name = "name" borderSize = { x = 3 y = 2 } }
+                    listBoxType = { name = "list" }
+                    smoothListBoxType = { name = "smooth_list" }
+                    overlappingElementsBoxType = { name = "overlap" }
+                    dropDownBoxType = {
+                        name = "dropdown"
+                        editBoxType = { name = "dropdown_edit" }
+                        expandButton = { name = "expand" spriteType = "GFX_button" }
+                        expandedWindow = { name = "expanded" show_position = { x = 0 y = 25 } }
+                    }
+                    extendedScrollbarType = { name = "scrollbar" slider = { name = "slider" spriteType = "GFX_slider" } }
+                }
+                scrollbarType = {
+                    name = "top_level_scrollbar" horizontal = 1
+                    slider = "slider" track = "track" leftButton = "left" rightButton = "right"
+                    guiButtonType = { parent = "slider" name = "down" }
+                }
+                extendedScrollbarType = { name = "top_level_extended_scrollbar" }
+            }
+        `), guiFileSchema);
+        const guiTypes = gui.guitypes[0];
+        const container = guiTypes.containerwindowtype[0];
+
+        assert.strictEqual(container.editboxtype.length, 1);
+        assert.strictEqual(container.editboxtype[0].bordersize?.x?._value, 3);
+        assert.strictEqual(container.editboxtype[0].bordersize?.y?._value, 2);
+        assert.strictEqual(container.listboxtype.length, 1);
+        assert.strictEqual(container.smoothlistboxtype.length, 1);
+        assert.strictEqual(container.overlappingelementsboxtype.length, 1);
+        assert.strictEqual(container.dropdownboxtype.length, 1);
+        assert.strictEqual(container.extendedscrollbartype.length, 1);
+        assert.strictEqual(container.extendedscrollbartype[0].slider?.name, 'slider');
+        const dropdown = container.dropdownboxtype[0];
+        assert.strictEqual(dropdown.editboxtype.length, 1);
+        assert.strictEqual(dropdown.editboxtype[0].name, 'dropdown_edit');
+        assert.strictEqual(dropdown.expandbutton?.name, 'expand');
+        assert.strictEqual(dropdown.expandedwindow?.name, 'expanded');
+        assert.strictEqual(dropdown.expandedwindow?.show_position?.x?._value, 0);
+        assert.strictEqual(dropdown.expandedwindow?.show_position?.y?._value, 25);
+        assert.strictEqual(guiTypes.scrollbartype.length, 1);
+        const scrollbar = guiTypes.scrollbartype[0];
+        assert.strictEqual(scrollbar.horizontal, 1);
+        assert.strictEqual(scrollbar.guibuttontype[0].parent, 'slider');
+        assert.deepStrictEqual([scrollbar.slider, scrollbar.track, scrollbar.leftbutton, scrollbar.rightbutton], ['slider', 'track', 'left', 'right']);
+        assert.strictEqual(guiTypes.extendedscrollbartype.length, 1);
     });
 });

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -3,6 +3,8 @@ import * as Mocha from 'mocha';
 import * as glob from 'glob';
 
 export function run(): Promise<void> {
+    Object.assign(globalThis, { IS_WEB_EXT: false });
+
     // Create the mocha test
     const mocha = new Mocha({
         ui: 'tdd',

--- a/webviewsrc/guipreview.ts
+++ b/webviewsrc/guipreview.ts
@@ -91,6 +91,21 @@ function setupContainerWindowToggles(folder: string) {
     }
 }
 
+function setupDropdownBoxes() {
+    const buttons = document.getElementsByClassName('gui-dropdown-button');
+    for (let i = 0; i < buttons.length; i++) {
+        const button = buttons.item(i) as HTMLElement;
+        button.addEventListener('click', event => {
+            event.stopPropagation();
+            const dropdown = button.closest('.gui-dropdown');
+            const expanded = dropdown?.querySelector<HTMLElement>(':scope > .gui-dropdown-expanded');
+            if (expanded) {
+                expanded.hidden = !expanded.hidden;
+            }
+        });
+    }
+}
+
 function refreshToggleVisibilityContent() {
     const mainContent = document.getElementById('mainContent') as HTMLDivElement;
     const toggleVisibilityContent = document.getElementById('toggleVisibilityContent') as HTMLDivElement;
@@ -115,6 +130,8 @@ window.addEventListener('load', tryRun(function() {
         refreshToggleVisibilityContent();
         setState({ toggleVisibilityContentVisible });
     });
+
+    setupDropdownBoxes();
 
     scrollToState();
     subscribeRefreshButton();


### PR DESCRIPTION
修改内容：
- 为 editBox、dropDownBox、overlappingElementsBox、smoothListBox、listBox、scrollbar 与 extendedScrollbar 补充与游戏格式一致的显式类型和 schema。
- 按原项目结构增加各控件族 renderer，并在 containerWindow 中继续使用显式分派；container 与 dropdown 仅通过文件内私有 helper 复用真正相同的基础子节点渲染。
- 支持 dropdown 的展开按钮、expandedWindow、show_position 和 Webview 点击展开，同时按源码 token 保持数组节点与单对象节点的正确层叠顺序。
- 补齐 Button renderer 已有 classNames 选项的输出，使 dropdown 直接复用现有按钮渲染逻辑。
- 支持 guiTypes 顶层 scrollbar 定义；标准 scrollbar 按同级按钮名称解析 parent 相对坐标，并按原版 horizontal = 0/1 语义处理横向坐标交换。
- 为 parent 链加入循环保护，并保留 extendedScrollbar 的背景和内联按钮渲染。
- 增加 parser 与 renderer 回归测试，覆盖控件分派、源码顺序、show_position、dropdown 交互、顶层 scrollbar、parent 定位及横向滚动条。

修改原因：
- 政治面板等复杂 GUI 大量使用这些通用控件；此前未进入 schema 的节点会被解析器直接忽略，导致预览出现大片空白、控件缺失和位置错误。
- 原版标准 scrollbar 的 horizontal 使用数值 0/1，按钮 parent 指向同一 scrollbar 内的其他按钮；若按普通独立按钮渲染，横向滚动条和两端按钮会产生确定性的坐标偏移。
- dropdown 的 expandButton 与 expandedWindow 是单对象，而其他子控件通常是数组项，必须统一依据源码 token 排序，才能保持游戏 GUI 的绘制层级。

设计原则：
- 不添加政治面板名称判断或页面专用布局。
- 保持原项目的显式 schema、独立 renderer、container 显式分派和既有 helper 复用方式。
- 不引入 registry、反射、通用布局引擎或跨层状态，控制改动边界和后续维护成本。

验证结果：
- TypeScript 编译通过。
- 生产代码 ESLint 检查通过。
- 5 个相关 GUI parser/renderer 单元测试通过。
- git diff --cached --check 通过。
- 国家的政治面板、生产面板、外交面板基本布局全部正常显示。部分子元素为定制元素无法直接展示和渲染